### PR TITLE
Add pre-commit hooks for formatting and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-yaml
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.3.3
+    hooks:
+      - id: prettier
+        additional_dependencies:
+          - prettier@3.3.3
+        files: "\\.(css|scss|less|html|js|jsx|ts|tsx|json|md|yaml|yml)$"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Install backend dependencies:
 npm run backend:install
 ```
 
+Install git hooks (optional but recommended):
+```zsh
+uv run pre-commit install
+```
+
 
 ### Running locally
 From the repo root:
@@ -61,6 +66,11 @@ This will automatically start both the frontend and backend, and proxy API reque
 From the repo root:
 ```zsh
 npm run backend:test
+```
+
+Run all pre-commit hooks manually:
+```zsh
+uv run pre-commit run --all-files
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,17 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "pre-commit>=3.8.0",
     "pytest>=8.4.2",
 ]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
## Summary
- add a modern pre-commit configuration with linting, formatting, and hygiene checks
- configure Ruff and register pre-commit as a development dependency
- document how to install and run the new git hooks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4f1efa2f48327a8b69fba47d7431c